### PR TITLE
feature: adding paths as optional array argument

### DIFF
--- a/src/Magentron/BladeLint/Console/Commands/BladeLint.php
+++ b/src/Magentron/BladeLint/Console/Commands/BladeLint.php
@@ -29,7 +29,7 @@ class BladeLint extends Command
      *
      * @var string
      */
-    protected $signature = 'blade:lint';
+    protected $signature = 'blade:lint {path?*}';
 
     /**
      * The console command description.
@@ -75,7 +75,7 @@ class BladeLint extends Command
         // get view directories
         $blades         = [];
         $files          = [];
-        $paths          = config('view.paths');
+        $paths          = $this->argument('path') ?: config('view.paths');
         $verbosityLevel = $this->getOutput()->getVerbosity();
 
         if (OutputInterface::VERBOSITY_VERBOSE < $verbosityLevel) {
@@ -87,7 +87,7 @@ class BladeLint extends Command
         // get all files in view directories
         foreach ($paths as $path) {
             $this->output->write(' - ' . $path, true, OutputInterface::VERBOSITY_VERY_VERBOSE);
-            $files = array_merge($files, File::allFiles($path));
+            $files = array_merge($files, is_file($path) ? [$path] : File::allFiles($path));
         }
         if (OutputInterface::VERBOSITY_VERBOSE === $verbosityLevel) {
             $this->output->writeln('', OutputInterface::VERBOSITY_VERBOSE);


### PR DESCRIPTION
closes #4 

## Context

In order to use `php artisan blade:lint` in my pre-commit hook, I need to be able to do something like:
```
"${modified} | grep .blade.php | xargs -r php artisan blade:lint"
```
So that only the `${modified}` files are scanned for defects.

## Proposal

I propose to add the following, backward compatible array parameter to the command:
```
blade:lint {path?*}
```

## Tests

Tested successfully on my Ubuntu 8.14 laptop witht PHP 7.4 and Laravel 7.23.